### PR TITLE
Update copyright year to 2026

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -157,7 +157,7 @@ export default function Footer() {
       </HygienRatingWrapper>
 
       <AdressLine>
-        <p>© 2024 MY PERSIAN KITCHEN</p>
+        <p>© 2026 MY PERSIAN KITCHEN</p>
       </AdressLine>
 
       <Me>


### PR DESCRIPTION
## Summary
- Bumps the footer copyright in `src/components/Footer.js` from 2024 to 2026.

https://claude.ai/code/session_01GVk4ZNyJVuERmQXoLXfxt8

---
_Generated by [Claude Code](https://claude.ai/code/session_01GVk4ZNyJVuERmQXoLXfxt8)_